### PR TITLE
Organized CLI option parsing with node-optimist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-node-cssmin.esproj
-.*
+node_modules

--- a/bin/cssmin
+++ b/bin/cssmin
@@ -1,21 +1,34 @@
 #!/usr/bin/env node
 // -*- js -*-
 
-var args = process.argv.slice(2);
+var
+fs = require("fs"),
+cssmin = require("../cssmin").cssmin,
+optimist = require("optimist");
+
+optimist
+    .usage("Usage: $0 [options] [<file>]\n\nIf no file is specified, assume stdin for input.")
+    .string("h")
+    .alias("h", "help")
+    .describe("help", "Print usage info"),
+argv = optimist.argv;
 
 function squeeze_out(css_in) {
-    process.stdout.write( require("cssmin").cssmin(css_in) );
+    process.stdout.write(cssmin(css_in));
 }
 
-if (args.length) {
-    require("fs").readFile( args[0], "utf8", function(err, css_in) {
+if (argv.h || argv.help) {
+    optimist.showHelp();
+}
+else if (argv._.length > 0) {
+    fs.readFile(argv._[0], "utf8", function(err, css_in) {
         if (err) {
             throw err;
         }
         else {
             squeeze_out(css_in);
         }
-    } );
+    });
 }
 else {
     var stdin = process.openStdin();

--- a/package.json
+++ b/package.json
@@ -1,17 +1,20 @@
 {
-	"name": "cssmin",
-	"version": "0.3.2",
-	"description": "A simple CSS minifier that uses a port of YUICompressor in JS",
-	"main": "cssmin",
-    "bin": {
-        "cssmin": "./bin/cssmin"
-    },
-	"author" : {
-		"name" : "Johan Bleuzen",
-		"url" : "http://blog.johanbleuzen.fr"
-	},
-    "repository" : {
-        "type" : "git",
-        "url"  : "http://github.com/jbleuzen/node-cssmin"
-    }
+  "name": "cssmin",
+  "version": "0.3.2",
+  "description": "A simple CSS minifier that uses a port of YUICompressor in JS",
+  "main": "cssmin",
+  "bin": {
+    "cssmin": "./bin/cssmin"
+  },
+  "author" : {
+    "name" : "Johan Bleuzen",
+    "url" : "http://blog.johanbleuzen.fr"
+  },
+  "repository" : {
+    "type" : "git",
+    "url"  : "http://github.com/jbleuzen/node-cssmin"
+  },
+  "dependencies": {
+    "optimist" : "0.4.0"
+  }
 }


### PR DESCRIPTION
I got tired of `ENOENT`, so I structured CLI parsing with node-optimist.

```
$ cssmin --help

/usr/local/share/npm/lib/node_modules/cssmin/bin/cssmin:13
            throw err;
                  ^
Error: ENOENT, open '--help'
```

now looks like:

```
$ cssmin --help
Usage: node ./bin/cssmin [options] [<file>]

If no file is specified, assume stdin for input.

Options:
  --help, -h  Print usage info
```
